### PR TITLE
adding "throttle" as an option to rate-limit the insertRows calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   "author": "Olof Dahlbom",
   "license": "MIT",
   "dependencies": {
-    "json-stringify-safe": "^5.0.1",
-    "react-native-invertible-scroll-view": "^1.1.0",
-    "moment": "^2.18.1",
     "debounce": "^1.0.2",
+    "json-stringify-safe": "^5.0.1",
+    "lodash.throttle": "4.1.1",
+    "moment": "^2.18.1",
+    "react-native-invertible-scroll-view": "^1.1.0",
     "stacktrace-parser": "^0.1.4"
   }
 }


### PR DESCRIPTION
The `insertStoreRows` function which writes log entries to the storage debounces its execution by 200 milliseconds by default. The log entries don't get flushed to the storage unless there is a 200ms gap between two log entries.

This PR adds `throttle` as an alternative method of rate-limiting. Throttled `insertStoreRows` flushes log entires to the storage every 200 milliseconds.