### PR TITLE
limiting the number of log rows kept in memory

### DIFF
--- a/debug-service.js
+++ b/debug-service.js
@@ -39,6 +39,8 @@ class DebugService {
             logAppState: true,
             logConnection: true,
             rateLimitingMethod: 'debounce', // 'debounce' || 'throttle'
+            loadExistingLogsOnStart: true,
+            sortExistingLogs: true,
             ...options,
         };
     }
@@ -168,12 +170,19 @@ class DebugService {
 
     async _initalGet() {
         this.initPromise = this.store.getRows();
-        const rows = await this.initPromise;
-        this.store.setReadOnly(false);
-        const newRows = this.logRows;
-        this.logRows = this.logRows.concat(rows);
-        this.sortLogRows();
-        await this.insertStoreRows(newRows);
+        if (this.options.loadExistingLogsOnStart === true) {
+            const rows = await this.initPromise;
+            this.store.setReadOnly(false);
+            const newRows = this.logRows;
+            this.logRows = this.logRows.concat(rows);
+            if (this.options.sortExistingLogs === true) {
+                this.sortLogRows();
+            }
+            await this.insertStoreRows(newRows);
+        } else {
+            this.store.setReadOnly(false);
+            await this.insertStoreRows(this.logRows);
+        }
         if (this.store.initalDataRead) {
             await this.store.initalDataRead(this.logRows);
         }
@@ -338,7 +347,7 @@ class DebugService {
                     console[this.options.logToConsoleMethod](...logRows);
                 }
             }
-   
+
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   "author": "Olof Dahlbom",
   "license": "MIT",
   "dependencies": {
-    "json-stringify-safe": "^5.0.1",
-    "react-native-invertible-scroll-view": "^1.1.0",
-    "moment": "^2.18.1",
     "debounce": "^1.0.2",
+    "json-stringify-safe": "^5.0.1",
+    "lodash.throttle": "4.1.1",
+    "moment": "^2.18.1",
+    "react-native-invertible-scroll-view": "^1.1.0",
     "stacktrace-parser": "^0.1.4"
   }
 }


### PR DESCRIPTION
* replacing the hard-coded 12000 character log message length with the configurable `maxMessageLength` option
* adding `maxNumberToKeepInMemory` as a configuration option